### PR TITLE
Fix garbage generation

### DIFF
--- a/AhoCorasick/AhoCorasick.cs
+++ b/AhoCorasick/AhoCorasick.cs
@@ -132,7 +132,7 @@ namespace Ganss.Text
 
             var word = node.Word;
             for (int i = 1; i < word.Length && node.Fail == null; i++)
-                node.Fail = Trie.ExploreFailLink(word.Substring(i));
+                node.Fail = Trie.ExploreFailLink(word, i, word.Length);
 
             foreach (var subNode in node.Next.Values)
                 BuildFail(subNode);

--- a/AhoCorasick/Trie.cs
+++ b/AhoCorasick/Trie.cs
@@ -87,10 +87,13 @@ namespace Ganss.Text
         }
 
         /// <summary>
-        /// Finds the failure node for a specified suffix.
+        /// Finds the failure node for a specified suffix within the given range of indices.
         /// </summary>
-        /// <param name="word">The suffix.</param>
-        /// <returns>The failure node or null.</returns>
+        /// <param name="word">The string containing the suffix.</param>
+        /// <param name="startIndex">The start index of the suffix within the string.</param>
+        /// <param name="endIndex">The end index (exclusive) of the suffix within the string.</param>
+        /// <returns>The failure node or null if no failure node is found.</returns>
+
         public virtual Trie ExploreFailLink(string word, int startIndex, int endIndex)
         {
             var node = this;

--- a/AhoCorasick/Trie.cs
+++ b/AhoCorasick/Trie.cs
@@ -91,14 +91,16 @@ namespace Ganss.Text
         /// </summary>
         /// <param name="word">The suffix.</param>
         /// <returns>The failure node or null.</returns>
-        public virtual Trie ExploreFailLink(string word)
+        public virtual Trie ExploreFailLink(string word, int startIndex, int endIndex)
         {
             var node = this;
 
-            foreach (var c in word)
+            for (int i = startIndex; i < endIndex; i++)
             {
-                node.Next.TryGetValue(c, out node);
-                if (node == null) return null;
+                if (!node.Next.TryGetValue(word[i], out node))
+                {
+                    return null;
+                }
             }
 
             return node;


### PR DESCRIPTION
Fixes the problem described at https://github.com/mganss/AhoCorasick/issues/85 

Instead of using string.substring which generates garbage it pass the startIndex/endIndex of same string